### PR TITLE
fix(deps): Use UTC-based date calculation to fix day offset

### DIFF
--- a/api/generate-ical.ts
+++ b/api/generate-ical.ts
@@ -23,16 +23,20 @@ const isStringDotString = (input: string): boolean => {
 
 const getDatesForWeeks = (numWeeks: number): string[] => {
   const dates: string[] = [];
-  const currentDate = new Date();
+  const today = new Date();
   
-  // On commence au début de la semaine courante pour être sûr d'avoir le contexte
-  const dayOfWeek = currentDate.getDay(); // 0 (Dim) - 6 (Sam)
-  const diff = currentDate.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1); // Ajuster au Lundi
-  currentDate.setDate(diff);
+  // Start of today, UTC, to prevent timezone offsets
+  const startOfToday = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+
+  const dayOfWeek = startOfToday.getUTCDay(); // 0 (Sun) - 6 (Sat)
+  const diff = dayOfWeek === 0 ? -6 : 1 - dayOfWeek; // Adjust to Monday
+  
+  const monday = new Date(startOfToday);
+  monday.setUTCDate(startOfToday.getUTCDate() + diff);
 
   for (let i = 0; i < numWeeks * 7; i++) {
-    const d = new Date(currentDate);
-    d.setDate(d.getDate() + i);
+    const d = new Date(monday);
+    d.setUTCDate(monday.getUTCDate() + i);
     dates.push(d.toISOString().split('T')[0]);
   }
   return dates;

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -26,32 +26,36 @@ const assignColors = (schedule: Day[]): Day[] => {
 };
 
 function getWorkingDays(dateInput?: string | number | null): string[] {
-    const currentDate = new Date();
-
+    const today = new Date();
+    
     let weeksToAdd = 0;
     if (typeof dateInput === "string" && /^-?\d+$/.test(dateInput)) {
         weeksToAdd = parseInt(dateInput, 10);
     } else if (typeof dateInput === "number") {
         weeksToAdd = dateInput;
     }
-
+    
     if (weeksToAdd !== 0) {
-        currentDate.setDate(currentDate.getDate() + weeksToAdd * 7);
+      today.setDate(today.getDate() + weeksToAdd * 7);
     }
 
-    const dayOfWeek = currentDate.getDay();
-    const diffToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
-    const monday = new Date(currentDate);
-    monday.setDate(currentDate.getDate() + diffToMonday);
+    // Start of day, UTC, to prevent timezone offsets
+    const startOfToday = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
 
-    const workingDays: Date[] = [];
+    const dayOfWeek = startOfToday.getUTCDay(); // 0 (Sun) - 6 (Sat)
+    const diffToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek; // Adjust to Monday
+    
+    const monday = new Date(startOfToday);
+    monday.setUTCDate(startOfToday.getUTCDate() + diffToMonday);
+
+    const workingDays: string[] = [];
     for (let i = 0; i < 7; i++) {
         const d = new Date(monday);
-        d.setDate(monday.getDate() + i);
-        workingDays.push(d);
+        d.setUTCDate(monday.getUTCDate() + i);
+        workingDays.push(d.toISOString().split("T")[0]);
     }
 
-    return workingDays.map((d) => d.toISOString().split("T")[0]);
+    return workingDays;
 }
 
 const parseHtmlDay = (html: string): Course[] => {


### PR DESCRIPTION
Fixes an issue where courses were appearing one day late in both the web UI and the iCal feed.

The previous date generation logic was susceptible to timezone-related errors on both the client and server, causing an off-by-one-day bug.

This commit refactors the  and  functions to be explicitly UTC-based by using , , and starting from a zeroed-out UTC date. This ensures consistent and correct date calculations regardless of the execution environment's timezone.

Issues : #43 