### PR TITLE
fix(ui): Ensure consistent day sorting in week view

### DIFF
--- a/src/components/schedule/TimeGrid.tsx
+++ b/src/components/schedule/TimeGrid.tsx
@@ -118,7 +118,12 @@ const TimeGrid = ({ schedule, currentDate = new Date(), onSelectDay }: TimeGridP
   const [now, setNow] = useState<Date>(new Date());
   const [displayHours, setDisplayHours] = useState<string[]>([]);
   const dayStartMinutes = useMemo(() => parseHHmmToMinutes(displayHours[0] || "08:00"), [displayHours]);
-  const workingDays: string[] = useMemo(() => JSON.parse(localStorage.getItem("workingDays") || '["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi"]'), []);
+  const workingDays: string[] = useMemo(() => {
+    const dayOrder = ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"];
+    const savedDays: string[] = JSON.parse(localStorage.getItem("workingDays") || '["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi"]');
+    
+    return savedDays.sort((a, b) => dayOrder.indexOf(a) - dayOrder.indexOf(b));
+  }, []);
 
   useEffect(() => {
     const id = setInterval(() => setNow(new Date()), 30000);


### PR DESCRIPTION
Fixes an issue where the days of the week in the  component would appear in a chaotic order if they were selected out of order in the settings.

- The  array fetched from  is now explicitly sorted chronologically from Monday to Sunday.
- This ensures a consistent and predictable display order in the week view header and grid, regardless of user selection order.

Issue : #45 