### PR TITLE
fix(ui): Use inline style for dynamic grid columns

### DIFF
--- a/src/components/schedule/TimeGrid.tsx
+++ b/src/components/schedule/TimeGrid.tsx
@@ -182,7 +182,7 @@ const TimeGrid = ({ schedule, currentDate = new Date(), onSelectDay }: TimeGridP
         <>
           {/* Header cliquable */}
           <div className="hidden md:block">
-            <div className={`grid grid-cols-[80px_repeat(${workingDays.length},1fr)] border-b border-border/50 bg-muted/30`}>
+            <div className="grid border-b border-border/50 bg-muted/30" style={{ gridTemplateColumns: `80px repeat(${workingDays.length}, 1fr)` }}>
               <div className="p-4 border-r border-border/50" />
               {workingDays.map((day) => {
                 const dayData = schedule.find((d) => d.day === day);
@@ -212,7 +212,7 @@ const TimeGrid = ({ schedule, currentDate = new Date(), onSelectDay }: TimeGridP
             </div>
 
             {/* Grille horaire */}
-            <div className={`grid grid-cols-[80px_repeat(${workingDays.length},1fr)] relative`}>
+            <div className="grid relative" style={{ gridTemplateColumns: `80px repeat(${workingDays.length}, 1fr)` }}>
               {/* Colonne heures */}
               <div className="border-r border-border/50">
                 {displayHours.map((hour) => (


### PR DESCRIPTION
Fixes a visual bug where the week view grid did not adapt correctly when the number of selected days was not 5.

- Replaces the dynamic Tailwind  class with an inline  attribute.
- This ensures the  property is always calculated correctly at runtime, bypassing potential Tailwind JIT compiler issues with dynamic class generation.

Issue : #47 