### PR TITLE
fix: Save "don't show again" choice on confirm

### DIFF
--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -11,31 +11,22 @@ export const InfoModal: React.FC<InfoModalProps> = ({
   storageKey = 'infoModal:hidden',
 }) => {
   const closeBtnRef = useRef<HTMLButtonElement>(null);
-  const [doNotShowAgain, setDoNotShowAgain] = useState<boolean>(false);
-
-  useEffect(() => {
+  const [isChecked, setIsChecked] = useState(() => {
     try {
-      const saved = typeof window !== 'undefined' ? window.localStorage.getItem(storageKey) : null;
-      setDoNotShowAgain(saved === 'true');
+      return window.localStorage.getItem(storageKey) === 'true';
     } catch {
-      // Erreur de localStorage ignorée
+      return false;
     }
-  }, [storageKey]);
+  });
 
   useEffect(() => {
-    if (open && doNotShowAgain) {
-      onClose();
-    }
-  }, [open, doNotShowAgain, onClose]);
-
-  useEffect(() => {
-    if (open && !doNotShowAgain) {
+    if (open) {
       const id = setTimeout(() => {
         closeBtnRef.current?.focus();
       }, 50);
       return () => clearTimeout(id);
     }
-  }, [open, doNotShowAgain]);
+  }, [open]);
 
   const onBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
     onClose();
@@ -46,20 +37,19 @@ export const InfoModal: React.FC<InfoModalProps> = ({
   };
 
   const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const checked = e.target.checked;
-    setDoNotShowAgain(checked);
+    setIsChecked(e.target.checked);
+  };
+
+  const handleConfirm = () => {
     try {
-      if (typeof window !== 'undefined') {
-        window.localStorage.setItem(storageKey, checked ? 'true' : 'false');
-      }
-    } catch {
-      // Erreur de localStorage ignorée
-    }
+      window.localStorage.setItem(storageKey, String(isChecked));
+    } catch {}
+    onClose();
   };
 
   return (
     <AnimatePresence>
-      {open && !doNotShowAgain && (
+      {open && (
         <motion.div
           key="backdrop"
           className="fixed inset-0 z-[1000] flex items-center justify-center"
@@ -116,7 +106,7 @@ export const InfoModal: React.FC<InfoModalProps> = ({
                 <input
                   type="checkbox"
                   className="h-4 w-4 rounded border border-white/40 dark:border-white/20 bg-white/30 dark:bg-white/10"
-                  checked={doNotShowAgain}
+                  checked={isChecked}
                   onChange={handleCheckboxChange}
                   aria-label="Ne plus afficher ce message"
                 />
@@ -127,7 +117,7 @@ export const InfoModal: React.FC<InfoModalProps> = ({
                 <button
                   ref={closeBtnRef}
                   type="button"
-                  onClick={onClose}
+                  onClick={handleConfirm}
                   className="inline-flex items-center rounded-lg px-4 py-2 text-sm font-medium
                              border border-white/40 dark:border-white/20
                              bg-white/30 dark:bg-white/10
@@ -160,5 +150,6 @@ export const InfoModal: React.FC<InfoModalProps> = ({
     </AnimatePresence>
   );
 };
+
 
 export default InfoModal;

--- a/src/hooks/useProtectedLogin.ts
+++ b/src/hooks/useProtectedLogin.ts
@@ -141,9 +141,13 @@ export const useProtectedLogin = (): UseProtectedLoginReturn => {
     });
 
     localStorage.setItem('hasVisited', 'true');
-    setInfoOpen(true);
+    if (localStorage.getItem('infoModal:hidden') !== 'true') {
+      setInfoOpen(true);
+    } else {
+      navigate('/calendar');
+    }
     setIsLoading(false);
-  }, [pin]);
+  }, [pin, navigate]);
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
@@ -209,7 +213,11 @@ export const useProtectedLogin = (): UseProtectedLoginReturn => {
     });
 
     localStorage.setItem('hasVisited', 'true');
-    setInfoOpen(true);
+    if (localStorage.getItem('infoModal:hidden') !== 'true') {
+      setInfoOpen(true);
+    } else {
+      navigate('/calendar');
+    }
   }, [username, needsPin, pin, navigate]);
 
   return {


### PR DESCRIPTION
This commit refactors the information modal and login logic to correctly handle the "ne plus afficher ce message" preference.

- In `InfoModal.tsx`, the checkbox state is now managed locally and only persisted to `localStorage` when the user clicks the "Compris" button. This ensures the choice is explicitly confirmed.
- The `useProtectedLogin` hook checks `localStorage` before showing the modal. If the user has previously opted out, they are redirected directly to the calendar.