### PR TITLE
fix(typing): Correct SubjectFilter props and state

### DIFF
--- a/src/components/schedule/SubjectFilter.tsx
+++ b/src/components/schedule/SubjectFilter.tsx
@@ -7,8 +7,8 @@ const SubjectFilter = ({
   subjects,
   selectedSubjects,
   onToggle,
-  filterDistanciel,
-  onToggleDistanciel,
+  remoteFilter,
+  onToggleRemote,
   defaultOpen = false,
 }: SubjectFilterProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(defaultOpen);
@@ -58,8 +58,8 @@ const SubjectFilter = ({
           <div className="flex items-center space-x-2 pb-2 border-b border-border">
             <Checkbox
               id="distanciel"
-              checked={filterDistanciel}
-              onCheckedChange={onToggleDistanciel}
+              checked={remoteFilter}
+              onCheckedChange={onToggleRemote}
             />
             <label
               htmlFor="distanciel"

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -66,7 +66,7 @@ const Calendar = () => {
   const [selectedSources, setSelectedSources] = useState<Set<string>>(
     new Set()
   );
-  const [filterDistanciel, setFilterDistanciel] = useState(false);
+  const [remoteFilter, setRemoteFilter] = useState(false);
   const [currentWeek, setCurrentWeek] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [viewMode, setViewMode] = useState<"week" | "day" | "month">("week");
@@ -233,11 +233,11 @@ const Calendar = () => {
           const matchSubject = selectedSubjects.has(course.subject);
           const matchSource = course.source ? selectedSources.has(course.source) : true;
           const matchDistanciel =
-            !filterDistanciel || course.room.startsWith("SALLE");
+            !remoteFilter || course.room.startsWith("SALLE");
           return matchSubject && matchSource && matchDistanciel;
         }) ?? [],
       }));
-  }, [schedule, selectedSubjects, selectedSources, filterDistanciel]);
+  }, [schedule, selectedSubjects, selectedSources, remoteFilter]);
 
   useEffect(() => {
     if (viewMode === "day") {
@@ -581,9 +581,9 @@ const Calendar = () => {
                 subjects={subjects}
                 selectedSubjects={selectedSubjects}
                 onToggle={handleSubjectToggle}
-                filterDistanciel={filterDistanciel}
-                onToggleDistanciel={() => {
-                  setFilterDistanciel((v) => !v);
+                remoteFilter={remoteFilter}
+                onToggleRemote={() => {
+                  setRemoteFilter((v) => !v);
                 }}
               />
             )}


### PR DESCRIPTION
This commit resolves a TypeScript error in `Calendar.tsx` where incorrect props were passed to the `SubjectFilter` component.

- The `filterDistanciel` and `onToggleDistanciel` props have been renamed to `remoteFilter` and `onToggleRemote` respectively in `SubjectFilter.tsx` and `Calendar.tsx` to match the `SubjectFilterProps` type definition.
- The corresponding state variable in `Calendar.tsx` has been renamed from `filterDistanciel` to `remoteFilter` for consistency.